### PR TITLE
feat: add support for html pings

### DIFF
--- a/articlefn/articlefn/add.py
+++ b/articlefn/articlefn/add.py
@@ -42,6 +42,7 @@ def _article_from_input(a: Dict[str, Any]) -> Article:
         "enriched": False,
         "claps": a.get('claps') or 0,
         "clappers": a.get('clappers') or 0,
+        "pings": 0,
         "date": now,
         "gsi1sk": now,
         "type": ARTICLE_TYPE,

--- a/design/openapi.yml
+++ b/design/openapi.yml
@@ -148,6 +148,26 @@ paths:
         404:
           description: Article not found
 
+  /articles/{articleId}/pings:
+    parameters:
+      - in: path
+        name: articleId
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      tags: [Public, Internal]
+      summary: Receives HTML a ping calls
+      description: >-
+        This endpoint is meant to be used in the "ping" attribute
+        of the "a" tag driving the user to the article. Like:
+        "<a href="<articleLink>" ping=".../articles/{articleId}/pings>"
+        to track clicks to the articles
+      responses:
+        204:
+          description: OK
+
 components:
   schemas:
     Article:


### PR DESCRIPTION
Add the `POST /articles/{articleId}/pings` endpoint for tracking visits to each article.

Sample usage in html is:

```html
<a link="<article.link>" ping="<apiurl>/articles/<article.id>/pings">The title of the article</a>
```

When the user clicks the link, most browsers will send a POST request to the ping url like this one:

```http
POST /api/articles/{articleId}/pings HTTP/1.1
Accept-Encoding: gzip, deflate
Connection: keep-alive
Content-Length: 5
Content-Type: text/ping
Host: b23tyqugr2.execute-api.eu-central-1.amazonaws.com
User-Agent: HTTPie/2.4.0

PING
```